### PR TITLE
构建json完成后直接创建任务

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "driver.js": "0.9.5",
     "dropzone": "5.5.1",
     "echarts": "4.2.1",
-    "element-ui": "2.7.0",
+    "element-ui": "2.13.0",
     "file-saver": "2.0.1",
     "fuse.js": "3.4.4",
     "js-cookie": "2.2.0",

--- a/src/api/datax-job-template.js
+++ b/src/api/datax-job-template.js
@@ -1,0 +1,48 @@
+import request from '@/utils/request'
+
+// datax插件api
+
+export function getList(params) {
+  return request({
+    url: 'api/jobTemplate/pageList',
+    method: 'get',
+    params
+  })
+}
+
+export function getExecutorList() {
+  return request({
+    url: 'api/jobGroup/list',
+    method: 'get'
+  })
+}
+
+export function updateJob(data) {
+  return request({
+    url: '/api/jobTemplate/update',
+    method: 'post',
+    data
+  })
+}
+
+export function createJob(data) {
+  return request({
+    url: '/api/jobTemplate/add/',
+    method: 'post',
+    data
+  })
+}
+
+export function removeJob(id) {
+  return request({
+    url: '/api/jobTemplate/remove/' + id,
+    method: 'post'
+  })
+}
+
+export function nextTriggerTime(cron) {
+  return request({
+    url: '/api/jobTemplate/nextTriggerTime?cron=' + cron,
+    method: 'get'
+  })
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -150,6 +150,12 @@ export const asyncRoutes = [
         meta: { title: '任务管理', icon: 'table' }
       },
       {
+        path: 'jobTemplate',
+        name: 'jobTemplate',
+        component: () => import('@/views/datax/jobTemplate/index'),
+        meta: { title: '任务模板管理', icon: 'table' }
+      },
+      {
         path: 'jobLog',
         name: 'jobLog',
         component: () => import('@/views/datax/jobLog/index'),

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -38,6 +38,7 @@ const actions = {
         const { roles } = response.content
         commit('SET_TOKEN', data)
         localStorage.setItem('roles', JSON.stringify(roles))
+        sessionStorage.setItem('username', username.trim())
         setToken(data)
         resolve()
       }).catch(error => {

--- a/src/views/datax/jobTemplate/index.vue
+++ b/src/views/datax/jobTemplate/index.vue
@@ -1,0 +1,422 @@
+<template>
+  <div class="app-container">
+    <div class="filter-container">
+      <el-input v-model="listQuery.jobDesc" placeholder="任务描述" style="width: 200px;" class="filter-item" />
+      <el-input v-model="listQuery.author" placeholder="负责人" style="width: 200px;" class="filter-item" />
+      <el-button v-waves class="filter-item" type="primary" icon="el-icon-search" @click="fetchData">
+        Search
+      </el-button>
+      <el-button class="filter-item" style="margin-left: 10px;" type="primary" icon="el-icon-edit" @click="handleCreate">
+        Add
+      </el-button>
+      <!-- <el-checkbox v-model="showReviewer" class="filter-item" style="margin-left:15px;" @change="tableKey=tableKey+1">
+        reviewer
+      </el-checkbox> -->
+    </div>
+    <el-table
+      v-loading="listLoading"
+      :data="list"
+      element-loading-text="Loading"
+      border
+      fit
+      highlight-current-row
+    >
+      <el-table-column align="center" label="任务ID" width="80">
+        <template slot-scope="scope">{{ scope.row.id }}</template>
+      </el-table-column>
+      <el-table-column label="任务描述" align="center">
+        <template slot-scope="scope">{{ scope.row.jobDesc }}</template>
+      </el-table-column>
+      <el-table-column label="Cron" align="center">
+        <template slot-scope="scope">
+          <span>{{ scope.row.jobCron }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="路由策略" align="center">
+        <template slot-scope="scope"> {{ routeStrategies.find(t => t.value === scope.row.executorRouteStrategy).label }}</template>
+      </el-table-column>
+      <el-table-column label="负责人" align="center">
+        <template slot-scope="scope">{{ scope.row.author }}</template>
+      </el-table-column>
+      <el-table-column label="注册节点" align="center">
+        <template slot-scope="scope">
+          <el-popover
+            placement="bottom"
+            width="500"
+            @show="loadById(scope.row)"
+          >
+            <el-table :data="registerNode">
+              <el-table-column width="150" property="title" label="执行器名称" />
+              <el-table-column width="150" property="appName" label="appName" />
+              <el-table-column width="150" property="registryList" label="机器地址" />
+            </el-table>
+            <el-button slot="reference">查看</el-button>
+          </el-popover>
+        </template>
+      </el-table-column>
+      <el-table-column label="下次触发时间" align="center">
+        <template slot-scope="scope">
+          <el-popover
+            placement="bottom"
+            width="300"
+            @show="nextTriggerTime(scope.row)"
+          >
+            <h5 v-html="triggerNextTimes" />
+            <el-button slot="reference">查看</el-button>
+          </el-popover>
+        </template>
+      </el-table-column>
+      <el-table-column label="Actions" align="center">
+        <template slot-scope="{row}">
+          <el-dropdown split-button type="primary">
+            操作
+            <el-dropdown-menu slot="dropdown">
+              <el-dropdown-item divided @click.native="handlerUpdate(row)">编辑</el-dropdown-item>
+              <el-dropdown-item @click.native="handlerDelete(row)">删除</el-dropdown-item>
+            </el-dropdown-menu>
+          </el-dropdown>
+        </template>
+      </el-table-column>
+    </el-table>
+    <pagination v-show="total>0" :total="total" :page.sync="listQuery.current" :limit.sync="listQuery.size" @pagination="fetchData" />
+
+    <el-dialog :title="textMap[dialogStatus]" :visible.sync="dialogFormVisible" width="1000px">
+      <el-form ref="dataForm" :rules="rules" :model="temp" label-position="left" label-width="110px">
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="执行器" prop="jobGroup">
+              <el-select v-model="temp.jobGroup" placeholder="请选择执行器">
+                <el-option v-for="item in executorList" :key="item.id" :label="item.title" :value="item.id" />
+              </el-select>
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="任务描述" prop="jobGroup">
+              <el-input v-model="temp.jobDesc" size="medium" placeholder="请输入任务描述" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="路由策略" prop="executorRouteStrategy">
+              <el-select v-model="temp.executorRouteStrategy" placeholder="请选择路由策略">
+                <el-option v-for="item in routeStrategies" :key="item.value" :label="item.label" :value="item.value" />
+              </el-select>
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="Cron" prop="jobCron">
+              <el-input v-model="temp.jobCron" placeholder="请输入Cron表达式" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="阻塞处理" prop="executorBlockStrategy">
+              <el-select v-model="temp.executorBlockStrategy" placeholder="请选择阻塞处理策略">
+                <el-option v-for="item in blockStrategies" :key="item.value" :label="item.label" :value="item.value" />
+              </el-select>
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="子任务ID">
+              <el-input v-model="temp.childJobId" placeholder="请输入子任务ID,多个以逗号分隔" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="任务超时时间">
+              <el-input v-model="temp.executorTimeout" placeholder="任务超时时间，单位秒，大于零时生效" />
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="负责人" prop="author">
+              <el-input v-model="temp.author" placeholder="请输入负责人" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="失败重试次数">
+              <el-input v-model="temp.executorFailRetryCount" placeholder="失败重试次数，大于零时生效" />
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="报警邮件">
+              <el-input v-model="temp.alarmEmail" placeholder="请输入报警邮件，多个用逗号分隔" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="增量时间字段">
+              <el-input v-model="temp.replaceParam" placeholder="-DlastTime='%s' -DcurrentTime='%s'" />
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="增量开始时间" prop="incStartTime">
+              <el-date-picker
+                v-model="temp.incStartTime"
+                type="datetime"
+                placeholder="首次增量使用"
+                format="yyyy-MM-dd HH:mm:ss"
+                default-time="00:00:00"
+              />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-row :gutter="20">
+          <el-col :span="24">
+            <el-form-item label="JVM启动参数">
+              <el-input v-model="temp.jvmParam" placeholder="-Xms1024m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+      </el-form>
+      <json-editor ref="jsonEditor" v-model="jobJson" />
+      <div slot="footer" class="dialog-footer">
+        <el-button @click="dialogFormVisible = false">
+          Cancel
+        </el-button>
+        <el-button type="primary" @click="dialogStatus==='create'?createData():updateData()">
+          Confirm
+        </el-button>
+      </div>
+    </el-dialog>
+  </div>
+</template>
+
+<script>
+import * as executor from '@/api/datax-executor'
+import * as job from '@/api/datax-job-template'
+import waves from '@/directive/waves' // waves directive
+import Pagination from '@/components/Pagination' // secondary package based on el-pagination
+import JsonEditor from '@/components/JsonEditor'
+
+export default {
+  name: 'JobTemplate',
+  components: { Pagination, JsonEditor },
+  directives: { waves },
+  filters: {
+    statusFilter(status) {
+      const statusMap = {
+        published: 'success',
+        draft: 'gray',
+        deleted: 'danger'
+      }
+      return statusMap[status]
+    }
+  },
+  data() {
+    const validateIncStartTime = (rule, value, callback) => {
+      if (this.temp.replaceParam && !this.temp.incStartTime) {
+        callback(new Error('incStartTime is required'))
+      }
+      callback()
+    }
+    return {
+      list: null,
+      listLoading: true,
+      total: 0,
+      listQuery: {
+        current: 1,
+        size: 10,
+        jobGroup: 0,
+        triggerStatus: -1,
+        jobDesc: '',
+        executorHandler: '',
+        author: ''
+      },
+      dialogPluginVisible: false,
+      pluginData: [],
+      dialogFormVisible: false,
+      dialogStatus: '',
+      textMap: {
+        update: 'Edit',
+        create: 'Create'
+      },
+      rules: {
+        jobGroup: [{ required: true, message: 'jobGroup is required', trigger: 'change' }],
+        executorRouteStrategy: [{ required: true, message: 'executorRouteStrategy is required', trigger: 'change' }],
+        executorBlockStrategy: [{ required: true, message: 'executorBlockStrategy is required', trigger: 'change' }],
+        jobDesc: [{ required: true, message: 'jobDesc is required', trigger: 'blur' }],
+        jobCron: [{ required: true, message: 'jobCron is required', trigger: 'blur' }],
+        author: [{ required: true, message: 'author is required', trigger: 'blur' }],
+        incStartTime: [{ trigger: 'blur', validator: validateIncStartTime }]
+      },
+      temp: {
+        id: undefined,
+        jobGroup: '',
+        jobCron: '',
+        jobDesc: '',
+        executorRouteStrategy: '',
+        executorBlockStrategy: '',
+        childJobId: '',
+        executorFailRetryCount: '',
+        alarmEmail: '',
+        executorTimeout: '',
+        author: '',
+        jobConfigId: '',
+        executorHandler: 'executorJobHandler',
+        glueType: 'BEAN',
+        jobJson: '',
+        executorParam: '',
+        replaceParam: '',
+        jvmParam: '',
+        timeOffset: 0,
+        incStartTime: ''
+      },
+      resetTemp() {
+        this.temp = this.$options.data().temp
+        this.jobJson = {}
+      },
+      executorList: '',
+      blockStrategies: [
+        { value: 'SERIAL_EXECUTION', label: '单机串行' },
+        { value: 'DISCARD_LATER', label: '丢弃后续调度' },
+        { value: 'COVER_EARLY', label: '覆盖之前调度' }
+      ],
+      routeStrategies: [
+        { value: 'FIRST', label: '第一个' },
+        { value: 'LAST', label: '最后一个' },
+        { value: 'ROUND', label: '轮询' },
+        { value: 'RANDOM', label: '随机' },
+        { value: 'CONSISTENT_HASH', label: '一致性HASH' },
+        { value: 'LEAST_FREQUENTLY_USED', label: '最不经常使用' },
+        { value: 'LEAST_RECENTLY_USED', label: '最近最久未使用' },
+        { value: 'FAILOVER', label: '故障转移' },
+        { value: 'BUSYOVER', label: '忙碌转移' }
+        // { value: 'SHARDING_BROADCAST', label: '分片广播' }
+      ],
+      triggerNextTimes: '',
+      registerNode: [],
+      jobJson: ''
+    }
+  },
+  created() {
+    this.fetchData()
+    this.getExecutor()
+  },
+
+  methods: {
+    getExecutor() {
+      job.getExecutorList().then(response => {
+        const { content } = response
+        this.executorList = content
+      })
+    },
+    fetchData() {
+      this.listLoading = true
+      job.getList(this.listQuery).then(response => {
+        const { content } = response
+        this.total = content.recordsTotal
+        this.list = content.data
+        this.listLoading = false
+      })
+    },
+    handleCreate() {
+      this.resetTemp()
+      this.dialogStatus = 'create'
+      this.dialogFormVisible = true
+      this.$nextTick(() => {
+        this.$refs['dataForm'].clearValidate()
+      })
+    },
+    createData() {
+      this.$refs['dataForm'].validate((valid) => {
+        if (valid) {
+          this.temp.jobJson = this.jobJson
+          job.createJob(this.temp).then(() => {
+            this.fetchData()
+            this.dialogFormVisible = false
+            this.$notify({
+              title: 'Success',
+              message: 'Created Successfully',
+              type: 'success',
+              duration: 2000
+            })
+          })
+        }
+      })
+    },
+    handlerUpdate(row) {
+      this.resetTemp()
+      this.temp = Object.assign({}, row) // copy obj
+      this.jobJson = JSON.parse(this.temp.jobJson)
+      this.dialogStatus = 'update'
+      this.dialogFormVisible = true
+      this.$nextTick(() => {
+        this.$refs['dataForm'].clearValidate()
+      })
+    },
+    updateData() {
+      this.$refs['dataForm'].validate((valid) => {
+        if (valid) {
+          this.temp.jobJson = typeof (this.jobJson) !== 'string' ? JSON.stringify(this.jobJson) : this.jobJson
+          job.updateJob(this.temp).then(() => {
+            this.fetchData()
+            this.dialogFormVisible = false
+            this.$notify({
+              title: 'Success',
+              message: 'Update Successfully',
+              type: 'success',
+              duration: 2000
+            })
+          })
+        }
+      })
+    },
+    handlerDelete(row) {
+      this.$confirm('确定删除吗？', '提示', {
+        confirmButtonText: '确定',
+        cancelButtonText: '取消',
+        type: 'warning'
+      }).then(() => {
+        job.removeJob(row.id).then(response => {
+          this.fetchData()
+          this.$notify({
+            title: 'Success',
+            message: 'Delete Successfully',
+            type: 'success',
+            duration: 2000
+          })
+        })
+      })
+
+      // const index = this.list.indexOf(row)
+    },
+    nextTriggerTime(row) {
+      job.nextTriggerTime(row.jobCron).then(response => {
+        const { content } = response
+        this.triggerNextTimes = content.join('<br>')
+        this.$notify({
+          title: 'Success',
+          message: 'Start Successfully',
+          type: 'success',
+          duration: 2000
+        })
+      })
+    },
+    loadById(row) {
+      executor.loadById(row.jobGroup).then(response => {
+        this.registerNode = []
+        const { content } = response
+        this.registerNode.push(content)
+        this.$notify({
+          title: 'Success',
+          message: 'Start Successfully',
+          type: 'success',
+          duration: 2000
+        })
+      })
+    }
+  }
+}
+</script>
+
+<style>
+  .el-dropdown + .el-dropdown {
+    margin-left: 15px;
+  }
+</style>

--- a/src/views/datax/json-build/index.vue
+++ b/src/views/datax/json-build/index.vue
@@ -8,7 +8,7 @@
         <el-step title="步骤 4" description="构建">4</el-step>
       </el-steps>
 
-      <!-- <el-button style="margin-top: 12px;" @click="last">上一步</el-button> -->
+      <el-button :disabled="active===1" style="margin-top: 12px;" @click="last">上一步</el-button>
       <el-button style="margin-top: 12px;margin-bottom: 12px;" @click="next">下一步</el-button>
 
       <div v-show="active===1" class="step1">
@@ -23,6 +23,72 @@
       <div v-show="active===4" class="step4">
         <el-button type="primary" @click="buildJson">构建</el-button>
         <el-button type="info" @click="handleCopy(inputData,$event)">copy json</el-button>
+        <el-button type="text" @click="handleJobTemplateSelectDrawer">{{ jobTemplate ? jobTemplate : "选择模板" }}</el-button>
+        <el-drawer
+          ref="jobTemplateSelectDrawer"
+          title="选择模板"
+          :visible.sync="jobTemplateSelectDrawer"
+          direction="rtl"
+          size="50%"
+        >
+          <el-table
+            v-loading="listLoading"
+            :data="list"
+            element-loading-text="Loading"
+            border
+            fit
+            highlight-current-row
+            destroy-on-close="true"
+            @current-change="handleCurrentChange"
+          >
+            <el-table-column align="center" label="任务ID" width="80">
+              <template slot-scope="scope">{{ scope.row.id }}</template>
+            </el-table-column>
+            <el-table-column label="任务描述" align="center">
+              <template slot-scope="scope">{{ scope.row.jobDesc }}</template>
+            </el-table-column>
+            <el-table-column label="Cron" align="center">
+              <template slot-scope="scope">
+                <span>{{ scope.row.jobCron }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column label="路由策略" align="center">
+              <template slot-scope="scope"> {{ routeStrategies.find(t => t.value === scope.row.executorRouteStrategy).label }}</template>
+            </el-table-column>
+            <el-table-column label="负责人" align="center">
+              <template slot-scope="scope">{{ scope.row.author }}</template>
+            </el-table-column>
+            <el-table-column label="注册节点" align="center">
+              <template slot-scope="scope">
+                <el-popover
+                  placement="bottom"
+                  width="500"
+                  @show="loadById(scope.row)"
+                >
+                  <el-table :data="registerNode">
+                    <el-table-column width="150" property="title" label="执行器名称" />
+                    <el-table-column width="150" property="appName" label="appName" />
+                    <el-table-column width="150" property="registryList" label="机器地址" />
+                  </el-table>
+                  <el-button slot="reference" @click.stop>查看</el-button>
+                </el-popover>
+              </template>
+            </el-table-column>
+            <el-table-column label="下次触发时间" align="center">
+              <template slot-scope="scope">
+                <el-popover
+                  placement="bottom"
+                  width="300"
+                  @show="nextTriggerTime(scope.row)"
+                >
+                  <h5 v-html="triggerNextTimes" />
+                  <el-button slot="reference" @click.stop>查看</el-button>
+                </el-popover>
+              </template>
+            </el-table-column>
+          </el-table>
+          <pagination v-show="total>0" :total="total" :page.sync="listQuery.current" :limit.sync="listQuery.size" @pagination="fetchData" />
+        </el-drawer>
         <div style="margin-bottom: 20px;" />
         <json-editor v-show="active===4" ref="jsonEditor" v-model="configJson" />
       </div>
@@ -32,6 +98,10 @@
 
 <script>
 import * as dataxJsonApi from '@/api/datax-json'
+import * as executor from '@/api/datax-executor'
+import * as jobTemplate from '@/api/datax-job-template'
+import * as job from '@/api/datax-job-info'
+import Pagination from '@/components/Pagination'
 import JsonEditor from '@/components/JsonEditor'
 import Reader from './reader'
 import Writer from './writer'
@@ -39,11 +109,67 @@ import clip from '@/utils/clipboard'
 import FieldMapper from './components/fieldMapper'
 
 export default {
-  components: { Reader, Writer, JsonEditor, FieldMapper },
+  components: { Reader, Writer, Pagination, JsonEditor, FieldMapper },
   data() {
     return {
       configJson: '',
-      active: 1
+      active: 1,
+      jobTemplate: '',
+      jobTemplateSelectDrawer: false,
+      list: null,
+      currentRow: null,
+      listLoading: true,
+      total: 0,
+      listQuery: {
+        current: 1,
+        size: 10,
+        jobGroup: 0,
+        triggerStatus: -1,
+        jobDesc: '',
+        executorHandler: '',
+        author: ''
+      },
+      blockStrategies: [
+        { value: 'SERIAL_EXECUTION', label: '单机串行' },
+        { value: 'DISCARD_LATER', label: '丢弃后续调度' },
+        { value: 'COVER_EARLY', label: '覆盖之前调度' }
+      ],
+      routeStrategies: [
+        { value: 'FIRST', label: '第一个' },
+        { value: 'LAST', label: '最后一个' },
+        { value: 'ROUND', label: '轮询' },
+        { value: 'RANDOM', label: '随机' },
+        { value: 'CONSISTENT_HASH', label: '一致性HASH' },
+        { value: 'LEAST_FREQUENTLY_USED', label: '最不经常使用' },
+        { value: 'LEAST_RECENTLY_USED', label: '最近最久未使用' },
+        { value: 'FAILOVER', label: '故障转移' },
+        { value: 'BUSYOVER', label: '忙碌转移' }
+        // { value: 'SHARDING_BROADCAST', label: '分片广播' }
+      ],
+      triggerNextTimes: '',
+      registerNode: [],
+      jobJson: '',
+      temp: {
+        id: undefined,
+        jobGroup: '',
+        jobCron: '',
+        jobDesc: '',
+        executorRouteStrategy: '',
+        executorBlockStrategy: '',
+        childJobId: '',
+        executorFailRetryCount: '',
+        alarmEmail: '',
+        executorTimeout: '',
+        author: '',
+        jobConfigId: '',
+        executorHandler: 'executorJobHandler',
+        glueType: 'BEAN',
+        jobJson: '',
+        executorParam: '',
+        replaceParam: '',
+        jvmParam: '',
+        incStartTime: ''
+      }
     }
   },
   created() {
@@ -66,10 +192,27 @@ export default {
         //   })
         // }
       } else {
-        if (this.active++ === 4) {
-          // 切回第一步
-          this.active = 1
+        if (this.active === 4) {
+          this.temp.jobJson = this.configJson
+          this.temp.author = sessionStorage.getItem('username')
+          job.createJob(this.temp).then(() => {
+            this.$notify({
+              title: 'Success',
+              message: 'Created Successfully',
+              type: 'success',
+              duration: 2000
+            })
+            // 切回第一步
+            this.active = 1
+          })
+        } else {
+          this.active++
         }
+      }
+    },
+    last() {
+      if (this.active > 1) {
+        this.active--
       }
     },
     beforeBuildJson() {
@@ -112,6 +255,52 @@ export default {
       this.$message({
         message: 'copy success',
         type: 'success'
+      })
+    },
+    handleJobTemplateSelectDrawer() {
+      this.jobTemplateSelectDrawer = !this.jobTemplateSelectDrawer
+      if (this.jobTemplateSelectDrawer) {
+        this.fetchData()
+        this.getExecutor()
+      }
+    },
+    getReaderData() {
+      console.info(this.$refs.reader.getData())
+      return this.$refs.reader.getData()
+    },
+    getExecutor() {
+      jobTemplate.getExecutorList().then(response => {
+        const { content } = response
+        this.executorList = content
+      })
+    },
+    fetchData() {
+      this.listLoading = true
+      jobTemplate.getList(this.listQuery).then(response => {
+        const { content } = response
+        this.total = content.recordsTotal
+        this.list = content.data
+        this.listLoading = false
+      })
+    },
+    nextTriggerTime(row) {
+      jobTemplate.nextTriggerTime(row.jobCron).then(response => {
+        const { content } = response
+        this.triggerNextTimes = content.join('<br>')
+      })
+    },
+    handleCurrentChange(val) {
+      this.temp = Object.assign({}, val)
+      this.temp.id = undefined
+      this.temp.jobDesc = this.getReaderData().tableName
+      this.$refs.jobTemplateSelectDrawer.closeDrawer()
+      this.jobTemplate = val.id + '(' + val.jobDesc + ')'
+    },
+    loadById(row) {
+      executor.loadById(row.jobGroup).then(response => {
+        this.registerNode = []
+        const { content } = response
+        this.registerNode.push(content)
       })
     }
   }

--- a/src/views/datax/json-build/writer.vue
+++ b/src/views/datax/json-build/writer.vue
@@ -12,6 +12,10 @@ export default {
   methods: {
     getData() {
       return this.$refs.writer.getData()
+    },
+    getReaderData() {
+      console.log('writer')
+      return this.$parent.getReaderData()
     }
   }
 }

--- a/src/views/datax/json-build/writer/testWriter.vue
+++ b/src/views/datax/json-build/writer/testWriter.vue
@@ -26,7 +26,7 @@
       <el-form-item label="表">
         <el-select
           v-model="writerForm.tableName"
-          :disabled="writerForm.ifStreamWriter"
+          :disabled="writerForm.ifCreateTable || writerForm.ifStreamWriter"
           filterable
           @change="wTbChange"
         >
@@ -37,6 +37,8 @@
             :value="item"
           />
         </el-select>
+        <el-checkbox v-model="writerForm.ifCreateTable" :disabled="writerForm.ifStreamWriter" @change="createTableCheckedChange">新增</el-checkbox>
+        <el-input v-show="writerForm.ifCreateTable" v-model="writerForm.tableName" style="width: 200px;" :placeholder="readerForm.tableName" />
       </el-form-item>
       <el-form-item label="字段">
         <el-checkbox v-model="writerForm.checkAll" :indeterminate="writerForm.isIndeterminate" @change="wHandleCheckAllChange">全选</el-checkbox>
@@ -70,8 +72,10 @@ export default {
         columns: [],
         checkAll: false,
         isIndeterminate: true,
-        preSql: ''
-      }
+        preSql: '',
+        ifCreateTable: false
+      },
+      readerForm: this.getReaderData()
     }
   },
   created() {
@@ -133,8 +137,18 @@ export default {
       this.writerForm.checkAll = checkedCount === this.wColumnList.length
       this.writerForm.isIndeterminate = checkedCount > 0 && checkedCount < this.wColumnList.length
     },
+    createTableCheckedChange(val) {
+      this.writerForm.tableName = val ? this.readerForm.tableName : ''
+      this.wColumnList = this.readerForm.columns
+      this.writerForm.columns = this.readerForm.columns
+      this.writerForm.checkAll = true
+      this.writerForm.isIndeterminate = false
+    },
     getData() {
       return this.writerForm
+    },
+    getReaderData() {
+      return this.$parent.getReaderData()
     }
   }
 }


### PR DESCRIPTION
- 添加任务模板管理界面
- json构建完成后，绑定模板创建任务
- writer界面预留创建表的选项，为后续在目标库创建表做准备
- 升级element-ui到2.13

> 由于绑定模板时，任务负责人从session中取当前用户，所以更新之后需重新登录，否则session中不存在用户名，导致从模板创建任务时失败。